### PR TITLE
Fix one import to fogbow manager that was moved to another package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/fogbowcloud/blowout/core/monitor/TaskMonitor.java
+++ b/src/main/java/org/fogbowcloud/blowout/core/monitor/TaskMonitor.java
@@ -79,7 +79,7 @@ public class TaskMonitor implements Runnable{
 		return this.runningTasks;
 	}
 	
-	protected void setRunningTasks(Map<Task, TaskProcess> runningTasks){
+	public void setRunningTasks(Map<Task, TaskProcess> runningTasks){
 		this.runningTasks = runningTasks;
 	}
 	

--- a/src/main/java/org/fogbowcloud/blowout/infrastructure/provider/fogbow/FogbowInfrastructureProvider.java
+++ b/src/main/java/org/fogbowcloud/blowout/infrastructure/provider/fogbow/FogbowInfrastructureProvider.java
@@ -33,7 +33,7 @@ import org.fogbowcloud.blowout.infrastructure.model.FogbowResource;
 import org.fogbowcloud.blowout.infrastructure.provider.InfrastructureProvider;
 import org.fogbowcloud.blowout.infrastructure.token.AbstractTokenUpdatePlugin;
 import org.fogbowcloud.blowout.pool.AbstractResource;
-import org.fogbowcloud.manager.core.UserdataUtils;
+import org.fogbowcloud.manager.core.util.UserdataUtils;
 import org.fogbowcloud.manager.occi.model.Token;
 import org.fogbowcloud.manager.occi.model.Token.User;
 import org.fogbowcloud.manager.occi.order.OrderAttribute;


### PR DESCRIPTION
One package from fogbow-manager was moved and that change was not reflected on blowout.
This is assuming that the package structure from the branch 'develop' will be maintained, as the other branches have that class as it is right now.